### PR TITLE
Support episode-less uploads + forward draft pk to portal

### DIFF
--- a/backend-lambda/src/handlers/beginUpload.ts
+++ b/backend-lambda/src/handlers/beginUpload.ts
@@ -39,15 +39,29 @@ export const beginUpload: APIGatewayProxyHandlerV2 = catchErrors(async (event) =
     return accessDenied();
   }
 
-  const presentation = presenterInfo.value.presentations.find((presentation) => presentation.pk === body.episode);
-  if (presentation === undefined) {
-    return invalidRequest();
+  // `episode` is nullable: the presenter portal allows "other" uploads
+  // (sponsor ads, promo clips, etc.) that aren't tied to a scheduled talk.
+  // When it is provided, it must match one of the presenter's talks.
+  let presentationSlug: string;
+  let episodeMetadata: string;
+  if (body.episode === null || body.episode === undefined) {
+    presentationSlug = 'other';
+    episodeMetadata = '';
+  } else {
+    const presentation = presenterInfo.value.presentations.find(
+      (presentation) => presentation.pk === body.episode,
+    );
+    if (presentation === undefined) {
+      return invalidRequest();
+    }
+    presentationSlug = presentation.slug;
+    episodeMetadata = `${presentation.pk}`;
   }
 
   const version = Date.now();
   const presenterName = sanitizeFileNames(presenterInfo.value.name);
 
-  const objectName = `${presenterName}/${presentation.slug}-${version}${extname(body.fileName)}`;
+  const objectName = `${presenterName}/${presentationSlug}-${version}${extname(body.fileName)}`;
 
   const { UploadId } = await client
     .createMultipartUpload({
@@ -56,7 +70,7 @@ export const beginUpload: APIGatewayProxyHandlerV2 = catchErrors(async (event) =
       Metadata: {
         presenterUuid: presenterInfo.value.uuid,
         presenterName: presenterInfo.value.name.normalize('NFD').replace(/[\u0300-\u036f]/g, ''),
-        episode: `${presentation.pk}`,
+        episode: episodeMetadata,
       },
     })
     .promise();
@@ -70,7 +84,8 @@ export const beginUpload: APIGatewayProxyHandlerV2 = catchErrors(async (event) =
         sub: UploadId,
         objectName: objectName,
         uuid: presenterInfo.value.uuid,
-        ep: body.episode,
+        ep: body.episode ?? null,
+        draft: body.draft ?? null,
       },
       jwtPrivateKey,
       {

--- a/backend-lambda/src/handlers/finishUpload.ts
+++ b/backend-lambda/src/handlers/finishUpload.ts
@@ -67,6 +67,7 @@ export const finishUpload: APIGatewayProxyHandlerV2 = catchErrors(async (event, 
         ETag,
         PartsCount,
       },
+      decodedToken.draft ?? null,
     );
 
     return response({ ok: true });

--- a/backend-lambda/src/portal-api.ts
+++ b/backend-lambda/src/portal-api.ts
@@ -33,21 +33,21 @@ export const notifyPortalUploadFinished = async (
   // `draft_pk` only when the portal handed us one on the way in — that's
   // how it matches the upload back to the pre-created draft row instead
   // of creating a duplicate.
-  const body: Record<string, unknown> = {
+  const payload: Record<string, unknown> = {
     presenter,
     episode,
     prerecord_url: prerecordUrl,
     prerecord_payload: JSON.stringify(prerecordPayload),
   };
   if (draft !== null && draft !== undefined) {
-    body.draft_pk = draft;
+    payload.draft_pk = draft;
   }
   const portalRequest = await fetch(`${portal}/upload/`, {
     method: 'POST',
     headers: {
       'content-type': 'application/json',
     },
-    body: JSON.stringify(body),
+    body: JSON.stringify(payload),
   });
 
   if (!(portalRequest.status >= 200 && portalRequest.status < 300)) {

--- a/backend-lambda/src/portal-api.ts
+++ b/backend-lambda/src/portal-api.ts
@@ -23,21 +23,31 @@ export const getPresenterInfo = async (presenter: string): Promise<Result<HTTPFa
 
 export const notifyPortalUploadFinished = async (
   presenter: string,
-  episode: number,
+  episode: number | null,
   prerecordUrl: string,
   prerecordPayload: unknown,
+  draft: number | null = null,
 ): Promise<Result<HTTPFailure, unknown>> => {
+  // Always send `episode` (possibly null) so the portal serializer can
+  // distinguish a talk-prerecord POST from an "other" upload. Include
+  // `draft_pk` only when the portal handed us one on the way in — that's
+  // how it matches the upload back to the pre-created draft row instead
+  // of creating a duplicate.
+  const body: Record<string, unknown> = {
+    presenter,
+    episode,
+    prerecord_url: prerecordUrl,
+    prerecord_payload: JSON.stringify(prerecordPayload),
+  };
+  if (draft !== null && draft !== undefined) {
+    body.draft_pk = draft;
+  }
   const portalRequest = await fetch(`${portal}/upload/`, {
     method: 'POST',
     headers: {
       'content-type': 'application/json',
     },
-    body: JSON.stringify({
-      presenter,
-      episode,
-      prerecord_url: prerecordUrl,
-      prerecord_payload: JSON.stringify(prerecordPayload),
-    }),
+    body: JSON.stringify(body),
   });
 
   if (!(portalRequest.status >= 200 && portalRequest.status < 300)) {

--- a/backend-lambda/src/types.ts
+++ b/backend-lambda/src/types.ts
@@ -1,7 +1,13 @@
 /** @see {isBeginBody} ts-auto-guard:type-guard */
 export interface BeginBody {
-  episode: number;
+  // `null` when the presenter portal is uploading an "other" file
+  // (sponsor ad, promo clip, ...) that isn't linked to a scheduled talk.
+  episode: number | null;
   fileName: string;
+  // Primary key of a pre-created VirtualEventPrerecordedFile draft row.
+  // Forwarded to the portal as `draft_pk` so the row is filled in place
+  // instead of a duplicate being created. Optional for backwards compat.
+  draft?: number | null;
 }
 
 /** @see {isUploadURLBody} ts-auto-guard:type-guard */
@@ -47,5 +53,6 @@ export interface DecodedUploadJWT {
   sub: string;
   objectName: string;
   uuid: string;
-  ep: number;
+  ep: number | null;
+  draft?: number | null;
 }

--- a/frontend/src/createUploadFile.ts
+++ b/frontend/src/createUploadFile.ts
@@ -11,12 +11,12 @@ export const createUploadFile = (
   setSpinnerHidden: SetHidden,
   debug: boolean,
   token: string,
-) => async (file: File, episode: number): Promise<void> => {
+) => async (file: File, episode: number | null, draft: number | null): Promise<void> => {
   try {
     setSpinnerHidden(false);
     progressBar.setHidden(false);
 
-    await upload(debug, token, file, episode, (loadedBytes) => {
+    await upload(debug, token, file, episode, draft, (loadedBytes) => {
       if (debug) {
         console.log('Updating progress...', loadedBytes, file.size, (loadedBytes / file.size) * 100);
       }
@@ -32,7 +32,8 @@ export const createUploadFile = (
     }
     Sentry.captureException(error, {
       tags: {
-        episode: `${episode}`,
+        episode: episode === null ? 'null' : `${episode}`,
+        draft: draft === null ? 'null' : `${draft}`,
         fileName: file.name,
       },
     });

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -13,6 +13,16 @@ import { setHidden, SetHidden } from './setHidden';
 import { createUploadFile } from './createUploadFile';
 import { getPortalDetails, isAPIError } from './uploader/apiCalls';
 
+// Parse an integer URL parameter, returning null when the parameter is
+// absent, empty, or non-numeric. Centralises the nullable-int parsing for
+// optional query params like ?episode= and ?draft=.
+const parseOptionalIntParam = (params: URLSearchParams, key: string): number | null => {
+  const raw = params.get(key);
+  if (raw === null) return null;
+  const parsed = parseInt(raw, 10);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
 console.log('process.env.SENTRY_DSN', process.env.SENTRY_DSN);
 
 if (process.env.SENTRY_DSN) {
@@ -56,21 +66,17 @@ const setup = async () => {
     const debug = params.has('debug');
     const presenter = params.get('presenter');
 
-    // `episode` is optional. The presenter portal's "Other Uploads" form
-    // lets presenters upload sponsor ads / promo clips that aren't
-    // attached to a specific scheduled talk. When it isn't provided (or
-    // is malformed) we skip the presentation lookup entirely.
-    const rawEpisode = params.get('episode');
-    const parsedEpisode = rawEpisode === null ? NaN : parseInt(rawEpisode, 10);
-    const episode: number | null = Number.isFinite(parsedEpisode) ? parsedEpisode : null;
-
-    // `draft` is the pk of a pre-created VirtualEventPrerecordedFile row
-    // that this upload should fill in. Forwarded to the portal as
-    // `draft_pk` at finish-upload time. Optional — legacy talk-prerecord
-    // flow doesn't use drafts.
-    const rawDraft = params.get('draft');
-    const parsedDraft = rawDraft === null ? NaN : parseInt(rawDraft, 10);
-    const draft: number | null = Number.isFinite(parsedDraft) ? parsedDraft : null;
+    // `episode` is the pk of the scheduled talk this upload is for. Optional:
+    // the presenter portal's "Other Uploads" form lets presenters upload
+    // sponsor ads / promo clips that aren't attached to a specific talk.
+    // When absent (or malformed) we skip the presentation lookup entirely.
+    //
+    // `draft` is the pk of a pre-created VirtualEventPrerecordedFile row that
+    // this upload should fill in. Forwarded to the portal as `draft_pk` at
+    // finish-upload time. Optional — legacy talk-prerecord flow doesn't use
+    // drafts.
+    const episode = parseOptionalIntParam(params, 'episode');
+    const draft = parseOptionalIntParam(params, 'draft');
 
     addBreadcrumb({
       category: 'setup',

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -5,8 +5,7 @@ import 'bootstrap';
 import 'bootstrap/dist/css/bootstrap.css'; // Import precompiled Bootstrap css
 import './css/frontend.css';
 
-import { addBreadcrumb, captureException, init, Severity } from '@sentry/browser';
-import { Integrations } from '@sentry/tracing';
+import { addBreadcrumb, browserTracingIntegration, captureException, init } from '@sentry/browser';
 
 import { createShowAlert } from './createShowAlert';
 import { createProgressBar } from './ProgressBar';
@@ -19,7 +18,7 @@ console.log('process.env.SENTRY_DSN', process.env.SENTRY_DSN);
 if (process.env.SENTRY_DSN) {
   init({
     dsn: process.env.SENTRY_DSN,
-    integrations: [new Integrations.BrowserTracing()],
+    integrations: [browserTracingIntegration()],
     tracesSampleRate: 0,
     release: `video-uploader@${process.env.RELEASE}`,
     environment: location.host,
@@ -76,7 +75,7 @@ const setup = async () => {
     addBreadcrumb({
       category: 'setup',
       message: `Looking for ${presenter} episode ${episode ?? 'none'} draft ${draft ?? 'none'}. Debug is ${debug ? 'on' : 'off'}`,
-      level: Severity.Info,
+      level: 'info',
     });
 
     const portalDetails = await getPortalDetails(presenter);
@@ -123,7 +122,7 @@ const setup = async () => {
         addBreadcrumb({
           category: 'file',
           message: 'User picked a file',
-          level: Severity.Info,
+          level: 'info',
         });
       }
     });
@@ -141,7 +140,7 @@ const setup = async () => {
       addBreadcrumb({
         category: 'file',
         message: 'Upload file...',
-        level: Severity.Info,
+        level: 'info',
       });
 
       await uploadFile(file, episode, draft);

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -56,11 +56,26 @@ const setup = async () => {
     const params = new URLSearchParams(window.location.search);
     const debug = params.has('debug');
     const presenter = params.get('presenter');
-    const episode = parseInt(params.get('episode'), 10);
+
+    // `episode` is optional. The presenter portal's "Other Uploads" form
+    // lets presenters upload sponsor ads / promo clips that aren't
+    // attached to a specific scheduled talk. When it isn't provided (or
+    // is malformed) we skip the presentation lookup entirely.
+    const rawEpisode = params.get('episode');
+    const parsedEpisode = rawEpisode === null ? NaN : parseInt(rawEpisode, 10);
+    const episode: number | null = Number.isFinite(parsedEpisode) ? parsedEpisode : null;
+
+    // `draft` is the pk of a pre-created VirtualEventPrerecordedFile row
+    // that this upload should fill in. Forwarded to the portal as
+    // `draft_pk` at finish-upload time. Optional — legacy talk-prerecord
+    // flow doesn't use drafts.
+    const rawDraft = params.get('draft');
+    const parsedDraft = rawDraft === null ? NaN : parseInt(rawDraft, 10);
+    const draft: number | null = Number.isFinite(parsedDraft) ? parsedDraft : null;
 
     addBreadcrumb({
       category: 'setup',
-      message: `Looking for ${presenter} episode ${episode}. Debug is ${debug ? 'on' : 'off'}`,
+      message: `Looking for ${presenter} episode ${episode ?? 'none'} draft ${draft ?? 'none'}. Debug is ${debug ? 'on' : 'off'}`,
       level: Severity.Info,
     });
 
@@ -75,14 +90,22 @@ const setup = async () => {
       throw new Error(`Could not obtain presenter (${presenter}) details: ${portalDetails.error}`);
     }
 
-    const presentation = portalDetails.presentations.find(({ pk }) => pk === episode);
-
-    if (!presentation) {
-      throw new Error(`Could not find episode: ${episode}`);
-    }
-
     presenterInput.value = portalDetails.name;
-    presentationTitle.value = presentation.name;
+
+    if (episode === null) {
+      // "Other" upload — no scheduled talk to look up. The presenter
+      // already picked the file's kind/title in the portal, so show a
+      // generic label here.
+      presentationTitle.value = 'Other upload';
+    } else {
+      const presentation = portalDetails.presentations.find(({ pk }) => pk === episode);
+
+      if (!presentation) {
+        throw new Error(`Could not find episode: ${episode}`);
+      }
+
+      presentationTitle.value = presentation.name;
+    }
 
     const uploadFile = createUploadFile(
       progressBar,
@@ -121,7 +144,7 @@ const setup = async () => {
         level: Severity.Info,
       });
 
-      await uploadFile(file, episode);
+      await uploadFile(file, episode, draft);
     };
 
     formEl.addEventListener(

--- a/frontend/src/uploader/apiCalls.ts
+++ b/frontend/src/uploader/apiCalls.ts
@@ -22,8 +22,12 @@ export const apiCall = async <T>(remoteURL: string, body: unknown, token?: strin
 };
 
 export type UploadIdResponse = APIError | (APIOK & { token: string });
-export const getUploadId = async (token: string, fileName: string, episode: number): Promise<UploadIdResponse> =>
-  apiCall('/begin', { fileName, episode }, token);
+export const getUploadId = async (
+  token: string,
+  fileName: string,
+  episode: number | null,
+  draft: number | null,
+): Promise<UploadIdResponse> => apiCall('/begin', { fileName, episode, draft }, token);
 
 export type GetPartURLResponse = APIError | (APIOK & { partURL: string });
 export const getPartURL = (token: string, partNumber: number): Promise<GetPartURLResponse> =>

--- a/frontend/src/uploader/upload.ts
+++ b/frontend/src/uploader/upload.ts
@@ -39,7 +39,8 @@ export const upload = async (
   debug: boolean,
   token: string,
   file: File,
-  episode: number,
+  episode: number | null,
+  draft: number | null,
   onProgress: (loadedBytes: number) => void,
 ): Promise<void> => {
   const partCounts = Math.ceil(file.size / FILE_CHUNK_SIZE);
@@ -50,7 +51,7 @@ export const upload = async (
     level: Severity.Info,
   });
 
-  const uploadIdResponse = await getUploadId(token, file.name, episode);
+  const uploadIdResponse = await getUploadId(token, file.name, episode, draft);
 
   if (isAPIError(uploadIdResponse)) {
     throw new Error(uploadIdResponse.error);

--- a/frontend/src/uploader/upload.ts
+++ b/frontend/src/uploader/upload.ts
@@ -6,7 +6,7 @@ export interface PartProgress {
 
 import pLimit from 'p-limit';
 import { abandonUpload, completeUpload, getPartURL, getUploadId, isAPIError } from './apiCalls';
-import { addBreadcrumb, Severity } from '@sentry/browser';
+import { addBreadcrumb } from '@sentry/browser';
 
 const FILE_CHUNK_SIZE = 10_000_000;
 
@@ -48,7 +48,7 @@ export const upload = async (
   addBreadcrumb({
     category: 'upload',
     message: 'Get Upload ID',
-    level: Severity.Info,
+    level: 'info',
   });
 
   const uploadIdResponse = await getUploadId(token, file.name, episode, draft);
@@ -91,7 +91,7 @@ export const upload = async (
     addBreadcrumb({
       category: 'upload',
       message: `Uploaded parts ${completedParts.length}`,
-      level: Severity.Info,
+      level: 'info',
     });
 
     const completeUploadResponse = await completeUpload(uploadToken, completedParts);
@@ -100,7 +100,7 @@ export const upload = async (
       addBreadcrumb({
         category: 'upload',
         message: `Error completing the upload: ${completeUploadResponse.error}`,
-        level: Severity.Fatal,
+        level: 'fatal',
       });
       throw new Error('Unable to complete upload.');
     }

--- a/frontend/src/uploader/uploadPart.ts
+++ b/frontend/src/uploader/uploadPart.ts
@@ -1,5 +1,5 @@
-import { addBreadcrumb, Severity } from '@sentry/browser';
-import axios from 'axios';
+import { addBreadcrumb } from '@sentry/browser';
+import axios, { AxiosProgressEvent } from 'axios';
 import { Part } from './apiCalls';
 
 export const uploadPart = async (
@@ -16,11 +16,11 @@ export const uploadPart = async (
   addBreadcrumb({
     category: 'uploadPart',
     message: `Uploading part ${partNumber}`,
-    level: Severity.Info,
+    level: 'info',
   });
 
   const output = await axios.put(uploadUrl, blob, {
-    onUploadProgress: (loadedBytes: ProgressEvent) => onProgress(loadedBytes.loaded),
+    onUploadProgress: (progressEvent: AxiosProgressEvent) => onProgress(progressEvent.loaded),
   });
 
   const etag = (output.headers as { etag: string }).etag;
@@ -29,7 +29,7 @@ export const uploadPart = async (
     addBreadcrumb({
       category: 'uploadPart',
       message: `Uploading part ${partNumber} returned headers ${JSON.stringify(output.headers)}`,
-      level: Severity.Info,
+      level: 'info',
     });
 
     throw new Error(`No etag returned with part ${partNumber}.`);


### PR DESCRIPTION
Hi Sophie 👋 — heads up before you dive in: **this PR was authored by an LLM (Claude)** driving a local dev session. I've reviewed it end-to-end and the type-checks pass, but please apply whatever level of scepticism feels appropriate. Apologies in advance for any "why would a human write it that way" moments. I've tried to keep commits small and self-explanatory, and the diff is ~120 lines.

## Context

The [veyepar](https://github.com/xfxf/veyepar) presenter portal (the Django side that redirects folks over here to upload) now supports **"Other Uploads"** — sponsor ads, promo clips, and other videos that aren't tied to a specific scheduled talk. To make those work end-to-end, the uploader needs to accept a redirect without `?episode=` and forward a new `?draft=` parameter back to the portal so the portal can match the finished upload to the row it pre-created.

Full portal-side contract: [`docs/dev/uploader-changes-for-presenter-portal-uploads.md`](https://github.com/xfxf/veyepar/blob/master/docs/dev/uploader-changes-for-presenter-portal-uploads.md) in veyepar.

Both changes are **backwards compatible** with the existing talk-prerecord happy path — legacy `?presenter=<uuid>&episode=<pk>` URLs produce the exact same POST-back shape as before.

## Contract changes

1. **`?episode=` is optional** on the redirect URL. When absent, the frontend skips the presentation lookup and the backend uses a fixed `other` slug for the S3 object key. `notifyPortalUploadFinished` sends `"episode": null` to the portal, which the portal's `PrerecordedFileSerializer` already accepts (`episode` is nullable on the model).
2. **`?draft=<pk>` is forwarded** as `draft_pk` in the final POST. Threaded through the multipart-upload JWT so it survives the full upload cycle. The portal uses `draft_pk` to fill the pre-created draft row in place instead of creating a duplicate.

## Commits

- **Support uploads without an episode, forward draft pk to portal** — the actual feature. `BeginBody.episode: number | null`, optional `BeginBody.draft`; `beginUpload` skips the presentation lookup when episode is null; JWT carries `ep` (nullable) and `draft`; `finishUpload` → `notifyPortalUploadFinished(..., draft)`; frontend parses both params, threads them through `createUploadFile` / `upload` / `getUploadId`.
- **Fix type errors from @sentry/browser v8 + axios upgrades** — five pre-existing `tsc` errors on `main`, caused by renovate-landed v8/v1 upgrades without follow-up code changes. Happy to split this into a separate PR if you'd prefer — just let me know. Specifically: `Severity` enum → string literals, `Integrations.BrowserTracing` → `browserTracingIntegration()`, `ProgressEvent` → `AxiosProgressEvent`.
- **Extract parseOptionalIntParam helper for URL params** — addressing Gemini review feedback on my fork.
- **Rename request payload to avoid shadowing in error branch** — addressing Copilot review feedback on my fork.

## Review history on my fork

I ran this through Copilot + Gemini on [xfxf/video-uploader#1](https://github.com/xfxf/video-uploader/pull/1) first. Both bots had one comment each (duplicate URL-param parsing; variable shadowing in the error branch) — both addressed in the commit log above.

## Test plan

- [x] `npx tsc --noEmit` passes cleanly in both `frontend/` and `backend-lambda/`
- [x] `ts-auto-guard` regenerates type guards for the updated `BeginBody` / `DecodedUploadJWT`
- [ ] End-to-end upload with `?presenter=<uuid>&episode=<pk>` (talk prerecord path — unchanged behaviour)
- [ ] End-to-end upload with `?presenter=<uuid>&draft=<pk>` (no `episode=` — arbitrary upload path)
- [ ] End-to-end upload with `?presenter=<uuid>&episode=<pk>&draft=<pk>` (targeted arbitrary upload)
- [ ] Confirm portal-side: `VirtualEventPrerecordedFile` draft row filled in place (no duplicate)

`eslint` is currently broken on `main` (stale `eslint-config-prettier@8` migration referencing `prettier/@typescript-eslint`) — not fixed here since it's independent of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)