### PR TITLE
Bump Lambda runtime from nodejs12.x to nodejs20.x

### DIFF
--- a/deployment.cfn.yaml
+++ b/deployment.cfn.yaml
@@ -106,7 +106,7 @@ Resources:
         S3Key: !Ref BackendLambdaS3Key
       Handler: src/index.presenterInfo
       Role: !GetAtt "BackendLambdaRole.Arn"
-      Runtime: "nodejs12.x"
+      Runtime: "nodejs20.x"
       Timeout: 25
       Environment:
         Variables:
@@ -123,7 +123,7 @@ Resources:
         S3Key: !Ref BackendLambdaS3Key
       Handler: src/index.getStream
       Role: !GetAtt "BackendLambdaRole.Arn"
-      Runtime: "nodejs12.x"
+      Runtime: "nodejs20.x"
       Timeout: 25
       Environment:
         Variables:
@@ -140,7 +140,7 @@ Resources:
         S3Key: !Ref BackendLambdaS3Key
       Handler: src/index.beginUpload
       Role: !GetAtt "BackendLambdaRole.Arn"
-      Runtime: "nodejs12.x"
+      Runtime: "nodejs20.x"
       Timeout: 25
       Environment:
         Variables:
@@ -157,7 +157,7 @@ Resources:
         S3Key: !Ref BackendLambdaS3Key
       Handler: src/index.getUploadURL
       Role: !GetAtt "BackendLambdaRole.Arn"
-      Runtime: "nodejs12.x"
+      Runtime: "nodejs20.x"
       Timeout: 25
       Environment:
         Variables:
@@ -174,7 +174,7 @@ Resources:
         S3Key: !Ref BackendLambdaS3Key
       Handler: src/index.finishUpload
       Role: !GetAtt "BackendLambdaRole.Arn"
-      Runtime: "nodejs12.x"
+      Runtime: "nodejs20.x"
       Timeout: 25
       Environment:
         Variables:
@@ -191,7 +191,7 @@ Resources:
         S3Key: !Ref BackendLambdaS3Key
       Handler: src/index.abandonUpload
       Role: !GetAtt "BackendLambdaRole.Arn"
-      Runtime: "nodejs12.x"
+      Runtime: "nodejs20.x"
       Timeout: 25
       Environment:
         Variables:


### PR DESCRIPTION
Heads-up: **this PR was authored by an LLM (Claude)** driving a local dev session; I've reviewed it end-to-end but please apply whatever level of scepticism feels appropriate. Companion to #99 — which triggered the first CI deploy attempt in ~2.5 years and surfaced this pre-existing breakage.

## The problem

The `uploader` CloudFormation stack in `ap-southeast-2` has been in `UPDATE_ROLLBACK_FAILED` since **2023-08-15T22:27 UTC**. Any subsequent deploy (including the one #99 triggered) fails at the `deploy-deployment.cfn.yaml.sh` step with:

> Stack:arn:aws:cloudformation:ap-southeast-2:.../stack/uploader/... is in UPDATE_ROLLBACK_FAILED state and can not be updated.

Looking at the 2023-08-15 stack events, every one of the six backend Lambda functions failed `UPDATE` with:

> The runtime parameter of nodejs12.x is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (nodejs18.x) while creating or updating functions.

The automatic rollback then tried to update them back — same error, same failure — so the stack ended up stuck.

AWS deprecated `nodejs12.x` for create/update in March 2023 and has since pulled `nodejs14.x` and `nodejs16.x` as well. The six live Lambdas are all still running `nodejs12.x` (last modified 2023-07-21); they still invoke, but CloudFormation cannot touch them.

## This change

Replace `Runtime: \"nodejs12.x\"` with `Runtime: \"nodejs20.x\"` on all six functions in ` + 'deployment.cfn.yaml' + ` (BackendPresenterInfoFn, BackendGetStreamFn, BackendBeginUploadInfoFn, BackendGetUploadURLFn, BackendFinishUploadFn, BackendAbandonUploadFn).

nodejs20.x matches the node version ` + '.github/workflows/main.yaml' + ` already uses to build the backend zip (` + 'setup-node@v2 node-version: \"20\"' + `), so the build artifact is compatible as-is.

## Test plan

- [ ] CFN template still parses (` + 'cfn-lint' + ` / ` + 'aws cloudformation validate-template' + ` — both clean locally)
- [ ] After unstick + merge, CI ` + 'Deploy Backend' + ` job completes without ` + 'ValidationError' + `
- [ ] Post-deploy: ` + 'aws lambda get-function --function-name uploader-BackendBeginUploadInfoFn-...' + ` reports ` + 'Runtime: nodejs20.x' + `
- [ ] Smoke test upload from the portal to confirm no runtime-level breakage (ESM/CJS differences, built-in API changes, etc. — the code is plain TS compiled through ts-loader, so nothing node-14/16/18-only should be in use)

## Notes

- There's also a stale 2021-01-01 ` + 'DELETE_FAILED' + ` on ` + 'BackendBucket' + ` ("bucket not empty") visible in stack history — harmless leftover drift, not on the critical path.
- Node 20 is in AWS's long-term support tier. Node 22 is available too if you'd rather skip straight there; happy to change if you prefer.